### PR TITLE
Hide classroom content

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,69 +1,74 @@
 <main class="tutorials">
-<h2><%= @facade.title %></h2>
-<h1 id="message"></h1>
-<div class="col col-4">
-  <h4>Videos</h4>
-  <ul>
-    <% @facade.videos.each do |video| %>
-      <li>
-        <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
-      </li>
-    <% end %>
-  </ul>
-</div>
-
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id), method: :post, class: "btn btn-outline mb1 teal" %>
+<% if !current_user.nil? || @facade.classroom == false %>
+  <h2><%= @facade.title %></h2>
+  <h1 id="message"></h1>
+  <div class="col col-4">
+    <h4>Videos</h4>
+    <ul>
+      <% @facade.videos.each do |video| %>
+        <li>
+          <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
+        </li>
       <% end %>
-    </div>
+    </ul>
   </div>
 
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
-        }
-      });
-    }
+  <div class="col col-8">
+    <div class="title-bookmark">
+      <h3><%= @facade.current_video.title %></h3>
+      <div class="bookmarks-btn">
+        <% if current_user %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% else %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% end %>
+      </div>
+    </div>
 
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
-
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+    <div id="player">
+      <script src="https://www.youtube.com/player_api"></script>
+      <script>
+      // create youtube player
+      var player;
+      var position;
+      function onYouTubePlayerAPIReady() {
+        player = new YT.Player('player', {
+          width: '640',
+          height: '390',
+          videoId: '<%= @facade.current_video.video_id %>',
+          events: {
+            onReady: onPlayerReady,
+            onStateChange: onPlayerStateChange
+          }
+        });
       }
-    }
-  </script>
-</div>
 
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
-</div>
+      // autoplay video
+      function onPlayerReady(event) {
+        event.target.playVideo();
+      }
 
+      // when video ends
+      function onPlayerStateChange(event) {
+        if(event.data === 0 && <%= @facade.play_next_video? %>) {
+          window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+        } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+          const message = document.querySelector(`#message`);
+          message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+        }
+      }
+    </script>
+  </div>
+
+    <h4>Description</h4>
+    <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+      <%= @facade.current_video.description.truncate(50) %>...
+      <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
+    </p>
+  </div>
+<% else %>
+<div class="sign-in">
+  <h3>Please <%= link_to "Sign In", login_path %> or <%= link_to "Register", register_path %> to continue</h3>
+</div>
+<% end %>
 </main>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,13 +4,15 @@
 </div>
 <section class="tutorials col md-col-8">
   <% @tutorials.each do |tutorial| %>
-    <div class="tutorial">
-      <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
-      <div class="tutorial-description col md-col-9">
-        <h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
-        <p class="description"><%= tutorial.description %></p> <br>
-      </div>
-    </div> <br>
+    <% if !current_user.nil? || tutorial.classroom == false %>
+      <div class='tutorial' id="tutorial-<%= tutorial.id %>">
+        <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
+        <div class="tutorial-description col md-col-9">
+          <h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
+          <p class="description"><%= tutorial.description %></p> <br>
+        </div>
+      </div> <br>
+    <% end %>
   <% end %>
   <hr>
   <br>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,7 @@ mod_3_tutorial_data = {
   "description"=>"Video content for Mod 3.",
   "thumbnail"=>"https://i.ytimg.com/vi/R5FPYQgB6Zc/hqdefault.jpg",
   "playlist_id"=>"PL1Y67f0xPzdOq2FcpWnawJeyJ3ELUdBkJ",
-  "classroom"=>false,
+  "classroom"=>true,
   "tag_list"=>["Internet", "BDD", "Ruby"],
 }
 m3_tutorial = Tutorial.create! mod_3_tutorial_data

--- a/spec/features/vistors/visitor_sees_homepage_spec.rb
+++ b/spec/features/vistors/visitor_sees_homepage_spec.rb
@@ -2,24 +2,32 @@ require 'rails_helper'
 
 describe 'Visitor' do
   describe 'on the home page' do
-    it 'can see a list of tutorials' do
+    it 'can see a list of tutorials not marked as classroom content only' do
       tutorial1 = create(:tutorial)
       tutorial2 = create(:tutorial)
+      tutorial3 = create(:tutorial, classroom: true)
 
       video1 = create(:video, tutorial_id: tutorial1.id)
       video2 = create(:video, tutorial_id: tutorial1.id)
       video3 = create(:video, tutorial_id: tutorial2.id)
       video4 = create(:video, tutorial_id: tutorial2.id)
+      video5 = create(:video, tutorial_id: tutorial3.id)
+      video6 = create(:video, tutorial_id: tutorial3.id)
 
       visit root_path
 
       expect(page).to have_css('.tutorial', count: 2)
 
-      within(first('.tutorials')) do
-        expect(page).to have_css('.tutorial')
+      within("#tutorial-#{tutorial1.id}") do
         expect(page).to have_css('.tutorial-description')
         expect(page).to have_content(tutorial1.title)
         expect(page).to have_content(tutorial1.description)
+      end
+
+      within("#tutorial-#{tutorial2.id}") do
+        expect(page).to have_css('.tutorial-description')
+        expect(page).to have_content(tutorial2.title)
+        expect(page).to have_content(tutorial2.description)
       end
     end
   end

--- a/spec/features/vistors/vistor_sees_a_video_show_spec.rb
+++ b/spec/features/vistors/vistor_sees_a_video_show_spec.rb
@@ -13,4 +13,21 @@ describe 'visitor sees a video show' do
     expect(page).to have_content(video.title)
     expect(page).to have_content(tutorial.title)
   end
+
+  it 'visitor cannot visit a tutorial that is classroom content only' do
+    tutorial1 = create(:tutorial)
+    tutorial2 = create(:tutorial, classroom: true)
+    video1 = create(:video, tutorial_id: tutorial1.id)
+    video2 = create(:video, tutorial_id: tutorial2.id)
+
+    visit '/'
+
+    expect(page).to have_link(tutorial1.title)
+    expect(page).to_not have_link(tutorial2.title)
+
+    visit "/tutorials/#{tutorial2.id}"
+    expect(page).to_not have_content(video2.title)
+    expect(page).to_not have_content(tutorial2.title)
+    expect(page).to have_content('Please Sign In or Register to continue')
+  end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,4 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
+  describe 'relationships' do
+    it { should have_many :videos }
+  end
 end


### PR DESCRIPTION
Complete Issue "Hide 'classroom content' from non-logged in users. #7"
1) I updated the welcome page to only return non-classroom content tutorials to a visitor who is not logged in. A default user will see all tutorials 
2) I updated the tutorials show page logic so a user cannot manually enter in a URL for a tutorial that is classroom content only. For example, if tutorial id # 3 has the classroom: true attribute, if a user tries to go to 'tutorials/3' they see a message saying they need to log in or register to continue and none of the tutorial content is returned to the visitor