### PR TITLE
GitHub followers

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
 
     github_results = GithubResults.new
     @repos = github_results.get_repos(current_user.token)[0..4]
+    @followers = github_results.get_followers(current_user.token)[0..4]
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
 
     github_results = GithubResults.new
     @repos = github_results.get_repos(current_user.token)[0..4]
-    @followers = github_results.get_followers(current_user.token)[0..4]
+    @followers = github_results.get_followers(current_user.token)
   end
 
   def new

--- a/app/poros/follower.rb
+++ b/app/poros/follower.rb
@@ -1,6 +1,6 @@
 class Follower
   attr_reader :login, :html_url
-  
+
   def initialize(follower_info)
     @login = follower_info[:login]
     @html_url = follower_info[:html_url]

--- a/app/poros/follower.rb
+++ b/app/poros/follower.rb
@@ -1,0 +1,8 @@
+class Follower
+  attr_reader :login, :html_url
+  
+  def initialize(follower_info)
+    @login = follower_info[:login]
+    @html_url = follower_info[:html_url]
+  end
+end

--- a/app/poros/github_results.rb
+++ b/app/poros/github_results.rb
@@ -4,4 +4,10 @@ class GithubResults
     json = github_service.user_repos(token)
     json.map { |repo| Repo.new(repo) }
   end
+
+  def get_followers(token)
+    github_service = GithubService.new
+    json = github_service.user_followers(token)
+    json.map { |repo| Follower.new(repo) }
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,6 +4,11 @@ class GithubService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def user_followers(user_token)
+    response = conn(user_token).get('user/followers')
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   def conn(user_token)
     Faraday.new(url: 'https://api.github.com') do |faraday|
       faraday.headers['Authorization'] = "token #{user_token}"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,8 +17,9 @@
       <% @repos.each do |repo| %>
         <p class='repo'><%= link_to repo.name, repo.html_url %></p>
       <% end %>
-    </section>
+    </section><br>
     <section class="<%= current_user.first_name %>-followers">
+      <h3>Your Github Followers</h3>
       <% @followers.each do |follower| %>
         <p class='follower'><%= link_to follower.login, follower.html_url %></p>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,5 +18,10 @@
         <p class='repo'><%= link_to repo.name, repo.html_url %></p>
       <% end %>
     </section>
+    <section class="<%= current_user.first_name %>-followers">
+      <% @followers.each do |follower| %>
+        <p class='follower'><%= link_to follower.login, follower.html_url %></p>
+      <% end %>
+    </section>
   <% end %>
 </section>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,3 +116,4 @@ m3_tutorial.videos.create!({
 })
 
 User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password:  "password", role: :admin)
+User.create!(email: 'daniel@example.com', first_name: 'Daniel', last_name: 'Atkinson', password:  "password", token: ENV['MY_GITHUB_KEY'])

--- a/spec/features/user/user_can_see_gh_followers_spec.rb
+++ b/spec/features/user/user_can_see_gh_followers_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'as a user I can visit my dahsboard' do
+  scenario 'I can see my followers on github' do
+    user1 = User.create(email: "mike@mike.com",
+                       first_name: "Mike",
+                       last_name: "Hernandez",
+                       password: "mike",
+                       token: ENV['GITHUB_API_KEY']
+                      )
+    user2 = User.create(email: "atkinson.daniel7@gmail.com",
+                       first_name: "Daniel",
+                       last_name: "Atkinson",
+                       password: "mike",
+                       token: ENV['MY_GITHUB_KEY']
+                      )
+    user3 = User.create(email: "bob@example.com",
+                       first_name: "Bob",
+                       last_name: "Example",
+                       password: "mike",
+                      )
+    visit '/'
+
+    click_on "Sign In"
+
+    expect(current_path).to eq(login_path)
+
+    fill_in 'session[email]', with: user1.email
+    fill_in 'session[password]', with: user1.password
+
+    click_on 'Log In'
+
+    within ".#{user1.first_name}-followers" do
+      expect(page).to have_link('leepanter')
+      expect(page).to have_link('alex-latham')
+      expect(page).to have_link('DavidTTran')
+      expect(page).to have_link('tylertomlinson')
+      page.assert_selector(:css, 'a[href="https://github.com/tylertomlinson"]')
+    end
+
+    click_button "Log Out"
+
+    click_on "Sign In"
+
+    expect(current_path).to eq(login_path)
+
+    fill_in 'session[email]', with: user2.email
+    fill_in 'session[password]', with: user2.password
+
+    click_on 'Log In'
+
+    expect(page).to_not have_css(".#{user1.first_name}-followers")
+
+    within ".#{user2.first_name}-followers" do
+      expect(page).to have_link('SMJ289')
+      expect(page).to have_link('alex-latham')
+      expect(page).to have_link('DavidTTran')
+      expect(page).to have_link('javier-aguilar')
+      page.assert_selector(:css, 'a[href="https://github.com/DavidTTran"]')
+    end
+
+    click_button "Log Out"
+
+    click_on "Sign In"
+
+    expect(current_path).to eq(login_path)
+
+    fill_in 'session[email]', with: user3.email
+    fill_in 'session[password]', with: user3.password
+
+    click_on 'Log In'
+
+    expect(page).to_not have_content("Your Github Followers")
+  end
+end

--- a/spec/poros/follower_spec.rb
+++ b/spec/poros/follower_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'Follower' do
+  it 'can return info about itself' do
+    follower_info = {login: "Daniel", html_url: "www.example.com"}
+    follower = Follower.new(follower_info)
+
+    expect(follower.login).to eq(follower_info[:login])
+    expect(follower.html_url).to eq(follower_info[:html_url])
+  end
+end

--- a/spec/poros/github_results_spec.rb
+++ b/spec/poros/github_results_spec.rb
@@ -8,5 +8,12 @@ describe 'Github Results' do
       expect(results.get_repos(ENV['GITHUB_API_KEY']).first).to be_a Repo
       expect(results.get_repos(ENV['GITHUB_API_KEY']).last).to be_a Repo
     end
+
+    it 'can return array of Follower objects' do
+      results = GithubResults.new
+      expect(results.get_followers(ENV['GITHUB_API_KEY'])).to be_an Array
+      expect(results.get_followers(ENV['GITHUB_API_KEY']).first).to be_a Follower
+      expect(results.get_followers(ENV['GITHUB_API_KEY']).last).to be_a Follower
+    end
   end
 end

--- a/spec/poros/repo_spec.rb
+++ b/spec/poros/repo_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
-describe 'Repo', type: :model do
-  describe 'Instance Methods' do
-    it 'can return info about itself' do
-      repo_info = {name: "Daniel", html_url: "www.example.com"}
-      repo = Repo.new(repo_info)
+describe 'Repo' do
+  it 'can return info about itself' do
+    repo_info = {name: "Daniel", html_url: "www.example.com"}
+    repo = Repo.new(repo_info)
 
-      expect(repo.name).to eq(repo_info[:name])
-      expect(repo.html_url).to eq(repo_info[:html_url])
-    end
+    expect(repo.name).to eq(repo_info[:name])
+    expect(repo.html_url).to eq(repo_info[:html_url])
   end
 end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,17 +1,24 @@
 require 'rails_helper'
 
 describe 'GithubService', type: :service do
-  it 'can get a response' do
-    user = User.create(email: "mike@mike.com",
-                       first_name: "Mike",
-                       last_name: "Hernandez",
-                       password: "mike",
-                       token: ENV['GITHUB_API_KEY']
-                      )
+  before(:each) do
+    @user = User.create(email: "mike@mike.com",
+      first_name: "Mike",
+      last_name: "Hernandez",
+      password: "mike",
+      token: ENV['GITHUB_API_KEY']
+    )
 
-    github_service = GithubService.new
+    @github_service = GithubService.new
+  end
 
-    expect(github_service.user_repos(user.token).first).to have_key :name
-    expect(github_service.user_repos(user.token).first).to have_key :html_url
+  it 'can get a response for user repos' do
+    expect(@github_service.user_repos(@user.token).first).to have_key :name
+    expect(@github_service.user_repos(@user.token).first).to have_key :html_url
+  end
+
+  it 'can get a response for user github followers' do
+    expect(@github_service.user_followers(@user.token).first).to have_key :login
+    expect(@github_service.user_followers(@user.token).first).to have_key :html_url
   end
 end


### PR DESCRIPTION
Complete User Dashboard: Github Followers #13
- Added @followers to users#show 
- Created Followers poro to turn json data from API call to users/follower into follower objects
- Added user_followers method in GithubService to return json data from API call to users/follower
- Added get_followers method in GithubResults to return an array of Followers
- RSpec and RuboCop 100% passing tests