### PR TITLE
Mh user following

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
 
     github_results = GithubResults.new
     @repos = github_results.get_repos(current_user.token)[0..4]
+    @following  = github_results.get_following(current_user.token)
   end
 
   def new

--- a/app/poros/following.rb
+++ b/app/poros/following.rb
@@ -1,0 +1,7 @@
+class Following
+  attr_reader :login, :html_url
+  def initialize(following_info)
+    @login = following_info[:login]
+    @html_url = following_info[:html_url]
+  end
+end

--- a/app/poros/github_results.rb
+++ b/app/poros/github_results.rb
@@ -4,4 +4,10 @@ class GithubResults
     json = github_service.user_repos(token)
     json.map { |repo| Repo.new(repo) }
   end
+
+  def get_following(token)
+    github_service = GithubService.new
+    json = github_service.user_following(token)
+    json.map { |following_user_info| Following.new(following_user_info)}
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,6 +4,11 @@ class GithubService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def user_following(user_token)
+    response = conn(user_token).get('user/following')
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   def conn(user_token)
     Faraday.new(url: 'https://api.github.com') do |faraday|
       faraday.headers['Authorization'] = "token #{user_token}"

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,5 +18,8 @@
         <p class='repo'><%= link_to repo.name, repo.html_url %></p>
       <% end %>
     </section>
+    <section class="<%= current_user.first_name %>-following">
+    
+    </section>
   <% end %>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,9 @@
       <% end %>
     </section>
     <section class="<%= current_user.first_name %>-following">
-    
+      <% @following.each do |user| %>
+        <p class='following-user'><%= link_to user.login, user.html_url %></p>
+      <% end %>
     </section>
   <% end %>
 </section>

--- a/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
+++ b/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe 'as a user when I visit my dashboard', type: :feature do
       visit dashboard_path
 
       within ".#{user1.first_name}-following" do
-        # expect(page).to have_link("Lee Panter")
+        expect(page).to have_link("leepanter")
+        expect(page).to have_link("DavidTTran")
+        expect(page).to have_link("tylertomlinson")
       end
     end
   end

--- a/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
+++ b/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'as a user when I visit my dashboard', type: :feature do
         expect(page).to have_link("leepanter")
         expect(page).to have_link("DavidTTran")
         expect(page).to have_link("tylertomlinson")
+        page.assert_selector(:css, 'a[href="https://github.com/leepanter"]')
       end
     end
   end

--- a/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
+++ b/spec/features/user/user_can_see_gh_users_they-follow_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'as a user when I visit my dashboard', type: :feature do
+  describe 'I can see all the users I follow on Github' do
+    it 'and their names are links to their Github profile' do
+      user1 = User.create(email: "mike@mike.com",
+                         first_name: "Mike",
+                         last_name: "Hernandez",
+                         password: "mike",
+                         token: ENV['GITHUB_API_KEY']
+                        )
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+      visit dashboard_path
+
+      within ".#{user1.first_name}-following" do
+        # expect(page).to have_link("Lee Panter")
+      end
+    end
+  end
+end

--- a/spec/poros/following_spec.rb
+++ b/spec/poros/following_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'following' do
+  describe 'instance methods' do
+    it 'has attributes' do
+      info = {login: 'abraham_lincoln',
+              html_url: 'https://www.whitehouse.gov/about-the-white-house/presidents/abraham-lincoln/'}
+      following = Following.new(info)
+
+      expect(following.login).to eq(info[:login])
+      expect(following.html_url).to eq(info[:html_url])
+    end
+  end
+end

--- a/spec/poros/github_results_spec.rb
+++ b/spec/poros/github_results_spec.rb
@@ -8,5 +8,12 @@ describe 'Github Results' do
       expect(results.get_repos(ENV['GITHUB_API_KEY']).first).to be_a Repo
       expect(results.get_repos(ENV['GITHUB_API_KEY']).last).to be_a Repo
     end
+
+    it 'can return array of following objects' do
+      results = GithubResults.new
+      expect(results.get_following(ENV['GITHUB_API_KEY'])).to be_an Array
+      expect(results.get_following(ENV['GITHUB_API_KEY']).first).to be_a Following
+      expect(results.get_following(ENV['GITHUB_API_KEY']).last).to be_a Following
+    end
   end
 end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'GithubService', type: :service do
-  it 'can get a response' do
+  it 'can get user repos' do
     user = User.create(email: "mike@mike.com",
                        first_name: "Mike",
                        last_name: "Hernandez",
@@ -13,5 +13,19 @@ describe 'GithubService', type: :service do
 
     expect(github_service.user_repos(user.token).first).to have_key :name
     expect(github_service.user_repos(user.token).first).to have_key :html_url
+  end
+
+  it 'can get users followed by the registered user' do
+    user = User.create(email: "mike@mike.com",
+                       first_name: "Mike",
+                       last_name: "Hernandez",
+                       password: "mike",
+                       token: ENV['GITHUB_API_KEY']
+                      )
+
+    github_service = GithubService.new
+
+    expect(github_service.user_following(user.token).first).to have_key :login
+    expect(github_service.user_following(user.token).first).to have_key :html_url
   end
 end


### PR DESCRIPTION
Creates functionality to show all registered users followed Github users
View updated to show followers - if logged in user has GH token
Following poro created with tests
GithubService methods updated to get proper following users endpoint
GithubResults methods updated to get proper following users endpoint
* Don't love the name 'Following' as it isn't very descriptive
* Don't love passing in more than one variable to the view
Overall, all is working tho
